### PR TITLE
Make parameter type descriptions optional

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,7 +3,10 @@ numpydoc.el NEWS -- history of user visible changes
 * Unreleased
 
 ** Changes
-TBD
+
+*** Added new defcustom: numpydoc-insert-paramter-types
+New variable controls whether the type hint is added to each argument
+in the parameters block (default is t).
 
 * 0.2.0 (Mar 5, 2021)
 

--- a/README.md
+++ b/README.md
@@ -89,17 +89,19 @@ See inside Emacs with <kbd>M-x customize-group RET numpydoc</kbd>
   </dd>
   <dt>numpydoc-insert-examples-block</dt>
   <dd>
-  If <code>t</code> an Examples block will be added to the docstring.
+  If <code>t</code> (the default) an Examples block will be added to
+  the docstring.
   </dd>
   <dt>numpydoc-insert-parameter-types</dt>
   <dd>
-  If <code>t</code> type hints from the function signature will be
-  used to add a type to each argument in the Parameters blocks.
+  If <code>t</code> (the default) type hints from the function
+  signature will be used to add a type to each argument in the
+  Parameters blocks of the docstring.
   </dd>
   <dt>numpydoc-insert-raises-block</dt>
   <dd>
-  If <code>t</code> a Raises bock will be added to the docstring if
-  exceptions are detected in the function body.
+  If <code>t</code> (the default) a Raises bock will be added to the
+  docstring if exceptions are detected in the function body.
   </dd>
   <dt>numpydoc-template-short</dt>
   <dd>

--- a/README.md
+++ b/README.md
@@ -91,6 +91,11 @@ See inside Emacs with <kbd>M-x customize-group RET numpydoc</kbd>
   <dd>
   If <code>t</code> an Examples block will be added to the docstring.
   </dd>
+  <dt>numpydoc-insert-parameter-types</dt>
+  <dd>
+  If <code>t</code> type hints from the function signature will be
+  used to add a type to each argument in the Parameters blocks.
+  </dd>
   <dt>numpydoc-insert-raises-block</dt>
   <dd>
   If <code>t</code> a Raises bock will be added to the docstring if

--- a/numpydoc.el
+++ b/numpydoc.el
@@ -372,12 +372,15 @@ This function assumes the cursor to be in the function body."
   (let ((tp type)
         (tmpt (cond ((numpydoc--yas-p) numpydoc--yas-replace-pat)
                     (t numpydoc-template-type-desc))))
-    (unless tp
-      (setq tp (if (numpydoc--prompt-p)
-                   (read-string (format "Type of %s: "
-                                        name))
-                 tmpt)))
-    (numpydoc--insert indent (format "%s : %s\n" name tp))))
+    (if numpydoc-insert-parameter-types
+        (progn
+          (unless tp
+            (setq tp (if (numpydoc--prompt-p)
+                         (read-string (format "Type of %s: "
+                                              name))
+                       tmpt)))
+          (numpydoc--insert indent (format "%s : %s\n" name tp)))
+      (numpydoc--insert-item indent name))))
 
 (defun numpydoc--insert-item-desc (indent element)
   "Insert ELEMENT parameter description at level INDENT."

--- a/numpydoc.el
+++ b/numpydoc.el
@@ -84,6 +84,11 @@ When nil, template text will be inserted."
   :group 'numpydoc
   :type 'boolean)
 
+(defcustom numpydoc-insert-parameter-types t
+  "Flag to control if Parameter types are inserted based on type hints."
+  :group 'numpydoc
+  :type 'boolean)
+
 (defcustom numpydoc-insert-raises-block t
   "Flag to control if the Raises section is inserted.
 This section will only be inserted if the flag is on and the function


### PR DESCRIPTION
New `defcustom` called `numpydoc-insert-parameter-types` (default set to `t`). If `t` types will be added to each member of the parameter block; if `nil`, no type is added. Closes https://github.com/douglasdavis/numpydoc.el/issues/4