### PR TITLE
Account for (), {}, and quote surrounded commas in default arguments.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,7 +4,7 @@ numpydoc.el NEWS -- history of user visible changes
 
 ** Fixed bugs
 
-*** Parsing default arguments containing commas or colon
+*** Parsing default arguments containing punctuation
 Arguments with commas surrounded by either quotes (strings), braces
 (dict or set), or parentheses (tuples) were causing bad docstrings.
 Default dicts with colons were also causing bad docstrings. (Issue

--- a/NEWS
+++ b/NEWS
@@ -2,7 +2,13 @@ numpydoc.el NEWS -- history of user visible changes
 
 * Unreleased
 
-TBD
+** Fixed bugs
+
+*** Parsing default arguments containing commas or colon
+Arguments with commas surrounded by either quotes (strings), braces
+(dict or set), or parentheses (tuples) were causing bad docstrings.
+Default dicts with colons were also causing bad docstrings. (Issue
+raised at GH #7, fixed at GH #8).
 
 * 0.4 (May 23, 2021)
 

--- a/numpydoc.el
+++ b/numpydoc.el
@@ -154,18 +154,20 @@ The argument takes on one of four possible styles:
    containing only '='. Example would be 'x=5'.
 4. Finally the default is an untyped argument without a default
    value. Example would be `x`."
-  (cond (;; type hint and default value
+  (cond (;; type hint and default value (or maybe a dict without a typehint)
          (and (s-contains-p ":" argstr) (s-contains-p "=" argstr))
-         (let* ((comps1 (s-split ":" argstr))
-                (comps2 (s-split "=" (nth 1 comps1)))
-                (name (s-trim (car comps1)))
-                (type (s-trim (car comps2)))
-                (defval (s-trim (nth 1 comps2))))
+         (let* ((type nil)
+                (comps1 (s-split "=" argstr))
+                (comps2 (s-split ":" (nth 0 comps1)))
+                (defval (s-trim (nth 1 comps1)))
+                (name (s-trim (car comps2)))
+                (type (cadr comps2)))
            (make-numpydoc--arg :name name
-                               :type type
+                               :type (if type (s-trim type) nil)
                                :defval defval)))
         ;; only a typehint
-        ((string-match-p ":" argstr)
+        ((and (string-match-p ":" argstr)
+              (not (s-contains-p "=" argstr)))
          (let* ((comps1 (s-split ":" argstr))
                 (name (s-trim (car comps1)))
                 (type (s-trim (nth 1 comps1))))
@@ -188,12 +190,23 @@ The argument takes on one of four possible styles:
 (defun numpydoc--split-args (fnargs)
   "Split FNARGS on comma but ignore those in type [brackets]."
   (let ((bc 0)
+        (inquote nil)
         (cursor -1)
         (strs '()))
     (dotimes (i (length fnargs))
       (let ((ichar (aref fnargs i)))
         (cond ((= ichar ?\[) (setq bc (1+ bc)))
               ((= ichar ?\]) (setq bc (1- bc)))
+              ((= ichar ?\() (setq bc (1+ bc)))
+              ((= ichar ?\)) (setq bc (1- bc)))
+              ((= ichar ?\{) (setq bc (1+ bc)))
+              ((= ichar ?\}) (setq bc (1- bc)))
+              ((= ichar ?\") (if inquote
+                                 (progn
+                                   (setq bc (1- bc)
+                                         inquote nil))
+                               (setq bc (1+ bc)
+                                     inquote t)))
               ((and (= ichar ?,) (= bc 0))
                (setq strs (append strs (list (substring fnargs
                                                         (1+ cursor)

--- a/numpydoc.el
+++ b/numpydoc.el
@@ -203,15 +203,13 @@ The argument takes on one of four possible styles:
               ((= ichar ?\{) (setq bc (1+ bc)))
               ((= ichar ?\}) (setq bc (1- bc)))
               ((= ichar ?\") (if indquote
-                                 (progn
-                                   (setq bc (1- bc)
-                                         indquote nil))
+                                 (setq bc (1- bc)
+                                       indquote nil)
                                (setq bc (1+ bc)
                                      indquote t)))
               ((= ichar ?\') (if insquote
-                                 (progn
-                                   (setq bc (1- bc)
-                                         insquote nil))
+                                 (setq bc (1- bc)
+                                       insquote nil)
                                (setq bc (1+ bc)
                                      insquote t)))
               ((and (= ichar ?,) (= bc 0))

--- a/numpydoc.el
+++ b/numpydoc.el
@@ -190,7 +190,8 @@ The argument takes on one of four possible styles:
 (defun numpydoc--split-args (fnargs)
   "Split FNARGS on comma but ignore those in type [brackets]."
   (let ((bc 0)
-        (inquote nil)
+        (indquote nil)
+        (insquote nil)
         (cursor -1)
         (strs '()))
     (dotimes (i (length fnargs))
@@ -201,12 +202,18 @@ The argument takes on one of four possible styles:
               ((= ichar ?\)) (setq bc (1- bc)))
               ((= ichar ?\{) (setq bc (1+ bc)))
               ((= ichar ?\}) (setq bc (1- bc)))
-              ((= ichar ?\") (if inquote
+              ((= ichar ?\") (if indquote
                                  (progn
                                    (setq bc (1- bc)
-                                         inquote nil))
+                                         indquote nil))
                                (setq bc (1+ bc)
-                                     inquote t)))
+                                     indquote t)))
+              ((= ichar ?\') (if insquote
+                                 (progn
+                                   (setq bc (1- bc)
+                                         insquote nil))
+                               (setq bc (1+ bc)
+                                     insquote t)))
               ((and (= ichar ?,) (= bc 0))
                (setq strs (append strs (list (substring fnargs
                                                         (1+ cursor)

--- a/numpydoc.el
+++ b/numpydoc.el
@@ -157,9 +157,9 @@ The argument takes on one of four possible styles:
   (cond (;; type hint and default value (or maybe a dict without a typehint)
          (and (s-contains-p ":" argstr) (s-contains-p "=" argstr))
          (let* ((type nil)
-                (comps1 (s-split "=" argstr))
-                (comps2 (s-split ":" (nth 0 comps1)))
-                (defval (s-trim (nth 1 comps1)))
+                (comps1 (s-split-up-to "=" argstr 1))
+                (comps2 (s-split-up-to ":" (car comps1) 1))
+                (defval (s-trim (cadr comps1)))
                 (name (s-trim (car comps2)))
                 (type (cadr comps2)))
            (make-numpydoc--arg :name name
@@ -168,7 +168,7 @@ The argument takes on one of four possible styles:
         ;; only a typehint
         ((and (string-match-p ":" argstr)
               (not (s-contains-p "=" argstr)))
-         (let* ((comps1 (s-split ":" argstr))
+         (let* ((comps1 (s-split-up-to ":" argstr 1))
                 (name (s-trim (car comps1)))
                 (type (s-trim (nth 1 comps1))))
            (make-numpydoc--arg :name name
@@ -176,7 +176,7 @@ The argument takes on one of four possible styles:
                                :defval nil)))
         ;; only a default value
         ((s-contains-p "=" argstr)
-         (let* ((comps1 (s-split "=" argstr))
+         (let* ((comps1 (s-split-up-to "=" argstr 1))
                 (name (s-trim (car comps1)))
                 (defval (s-trim (nth 1 comps1))))
            (make-numpydoc--arg :name name

--- a/tests/test-numpydoc.el
+++ b/tests/test-numpydoc.el
@@ -39,7 +39,20 @@ def somelongerfunc(
     a1: np.ndarray,
     a2: Optional[np.ndarray] = None,
     a3: Optional[Sequence[float]] = None,
-) -> Tuple[int, float]:"))
+) -> Tuple[int, float]:")
+        (fsig4 "\
+def f(
+    aa,
+    bb=(4, 6),
+    cc: set = {1, 2},
+    dd: Dict[str, int] = dict(a=1, b=2, c = 3),
+    ee: Dict[str, int] = {\"a\": 5, \"b\": 6},
+    ff={\"a\": 5, \"b\": 6},
+    gg=\"str,str\",
+    hh: str = \"str, str, str, str\",
+    ii: Tuple[int, ...] = (4, 6),
+    jj: str = \"str,str\",
+)"))
   (it "Checks arg parsing 1"
     (let ((a (make-numpydoc--arg :name "a" :type "int" :defval nil))
           (b (make-numpydoc--arg :name "b" :type "float" :defval "5.5"))
@@ -79,7 +92,51 @@ def somelongerfunc(
       (expect a1 :to-equal (car args))
       (expect a2 :to-equal (nth 1 args))
       (expect a3 :to-equal (nth 2 args))
-      (expect ret :to-equal "Tuple[int, float]"))))
+      (expect ret :to-equal "Tuple[int, float]")))
+
+  (it "Checks arg parsing 4"
+      (let ((aa (make-numpydoc--arg :name "aa"
+                                    :type nil
+                                    :defval nil))
+            (bb (make-numpydoc--arg :name "bb"
+                                    :type nil
+                                    :defval "(4, 6)"))
+            (cc (make-numpydoc--arg :name "cc"
+                                    :type "set"
+                                    :defval "{1, 2}"))
+            (dd (make-numpydoc--arg :name "dd"
+                                    :type "Dict[str, int]"
+                                    :defval "dict(a=1, b=2, c = 3)"))
+            (ee (make-numpydoc--arg :name "ee"
+                                    :type "Dict[str, int]"
+                                    :defval "{\"a\": 5, \"b\": 6}"))
+            (ff (make-numpydoc--arg :name "ff"
+                                    :type nil
+                                    :defval "{\"a\": 5, \"b\": 6}"))
+            (gg (make-numpydoc--arg :name "gg"
+                                    :type nil
+                                    :defval "\"str,str\""))
+            (hh (make-numpydoc--arg :name "hh"
+                                    :type "str"
+                                    :defval "\"str, str, str, str\""))
+            (ii (make-numpydoc--arg :name "ii"
+                                    :type "Tuple[int, ...]"
+                                    :defval "(4, 6)"))
+            (jj (make-numpydoc--arg :name "jj"
+                                    :type "str"
+                                    :defval "\"str,str\""))
+            (args (numpydoc--def-args (numpydoc--parse-def fsig4))))
+
+        (expect aa :to-equal (car args))
+        (expect bb :to-equal (nth 1 args))
+        (expect cc :to-equal (nth 2 args))
+        (expect dd :to-equal (nth 3 args))
+        (expect ee :to-equal (nth 4 args))
+        (expect ff :to-equal (nth 5 args))
+        (expect gg :to-equal (nth 6 args))
+        (expect hh :to-equal (nth 7 args))
+        (expect ii :to-equal (nth 8 args))
+        (expect jj :to-equal (nth 9 args)))))
 
 (provide 'test-numpydoc)
 ;;; test-numpydoc.el ends here


### PR DESCRIPTION
Should fix #7 