### PR TITLE
Add special cases of param names to ignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,11 @@ RET numpydoc</kbd>
   description if <code>numpydoc-insertion-style</code> is
   <code>nil</code>.
   </dd>
+  <dt>numpydoc-ignored-params</dt>
+  <dd>
+  All function parameters with names listed here will be ignored
+  when generating a docstring.
+  </dd>
 </dl>
 
 ## Examples

--- a/numpydoc.el
+++ b/numpydoc.el
@@ -266,7 +266,7 @@ This function assumes the cursor to be in the function body."
                                                           rawsig))))))
            ;; function args as a list of structures (remove some special cases)
            (args (-remove (lambda (x)
-                            (-contains-p (list "" "self" "*" "/")
+                            (-contains-p (list "" "self" "cls" "*" "*args" "**kwargs" "/")
                                          (numpydoc--arg-name x)))
                           (-map #'numpydoc--arg-str-to-struct rawargs)))
            ;; look for exceptions in the function body

--- a/numpydoc.el
+++ b/numpydoc.el
@@ -127,6 +127,12 @@ text, and below the Examples section."
   :group 'numpydoc
   :type 'string)
 
+(defcustom numpydoc-ignored-params (list "" "self" "cls" "*" "*args" "**kwargs" "/")
+  "All function parameters with names listed here will be ignored
+when generating a docstring."
+  :group 'numpydoc
+  :type '(repeat string))
+
 ;;; package implementation code.
 
 (cl-defstruct numpydoc--def
@@ -266,7 +272,7 @@ This function assumes the cursor to be in the function body."
                                                           rawsig))))))
            ;; function args as a list of structures (remove some special cases)
            (args (-remove (lambda (x)
-                            (-contains-p (list "" "self" "cls" "*" "*args" "**kwargs" "/")
+                            (-contains-p numpydoc-ignored-params
                                          (numpydoc--arg-name x)))
                           (-map #'numpydoc--arg-str-to-struct rawargs)))
            ;; look for exceptions in the function body

--- a/tests/test-numpydoc.el
+++ b/tests/test-numpydoc.el
@@ -52,6 +52,14 @@ def f(
     hh: str = \"str, str, str, str\",
     ii: tuple[int, ...] = (4, 6),
     jj: str = \"str,str\",
+)")
+        (fsig-ignored-args "\
+def func_with_ignored_args(
+    self,
+    a1: int,
+    a2: str,
+    *args,
+    **kwargs,
 )"))
   (it "Checks arg parsing 1"
     (let ((a (make-numpydoc--arg :name "a" :type "int" :defval nil))
@@ -136,7 +144,31 @@ def f(
         (expect gg :to-equal (nth 6 args))
         (expect hh :to-equal (nth 7 args))
         (expect ii :to-equal (nth 8 args))
-        (expect jj :to-equal (nth 9 args)))))
+        (expect jj :to-equal (nth 9 args))))
+  (it "Checks arg parsing for ignored param names"
+    (let* ((numpydoc-ignored-params (list "self" "*args" "**kwargs"))
+          (self (make-numpydoc--arg :name "self"
+                                  :type nil
+                                  :defval nil))
+          (a1 (make-numpydoc--arg :name "a1"
+                                  :type "int"
+                                  :defval nil))
+          (a2 (make-numpydoc--arg :name "a2"
+                                  :type "str"
+                                  :defval nil))
+          (pyargs (make-numpydoc--arg :name "*args"
+                                  :type nil
+                                  :defval nil))
+          (kwargs (make-numpydoc--arg :name "**kwargs"
+                                  :type nil
+                                  :defval nil))
+
+          (args (numpydoc--def-args (numpydoc--parse-def fsig-ignored-args))))
+      (expect a1 :to-equal (car args))
+      (expect a2 :to-equal (nth 1 args))
+      (expect args :not :to-contain self)
+      (expect args :not :to-contain pyargs)
+      (expect args :not :to-contain kwargs))))
 
 (provide 'test-numpydoc)
 ;;; test-numpydoc.el ends here

--- a/tests/test-numpydoc.el
+++ b/tests/test-numpydoc.el
@@ -147,21 +147,21 @@ def func_with_ignored_args(
         (expect jj :to-equal (nth 9 args))))
   (it "Checks arg parsing for ignored param names"
     (let* ((numpydoc-ignored-params (list "self" "*args" "**kwargs"))
-          (self (make-numpydoc--arg :name "self"
-                                  :type nil
-                                  :defval nil))
-          (a1 (make-numpydoc--arg :name "a1"
-                                  :type "int"
-                                  :defval nil))
-          (a2 (make-numpydoc--arg :name "a2"
-                                  :type "str"
-                                  :defval nil))
-          (pyargs (make-numpydoc--arg :name "*args"
-                                  :type nil
-                                  :defval nil))
-          (kwargs (make-numpydoc--arg :name "**kwargs"
-                                  :type nil
-                                  :defval nil))
+           (self (make-numpydoc--arg :name "self"
+                                     :type nil
+                                     :defval nil))
+           (a1 (make-numpydoc--arg :name "a1"
+                                   :type "int"
+                                   :defval nil))
+           (a2 (make-numpydoc--arg :name "a2"
+                                   :type "str"
+                                   :defval nil))
+           (pyargs (make-numpydoc--arg :name "*args"
+                                       :type nil
+                                       :defval nil))
+           (kwargs (make-numpydoc--arg :name "**kwargs"
+                                       :type nil
+                                       :defval nil))
 
           (args (numpydoc--def-args (numpydoc--parse-def fsig-ignored-args))))
       (expect a1 :to-equal (car args))


### PR DESCRIPTION
I've been using this package for docstrings lately (thank you for making it, it's very helpful!).
These are a few common cases of params that I don't want to make a docstring for. If you'd prefer, I'd also be happy to make this a customizable variable instead.