### PR TITLE
Adds defcustom numpydoc-newline-after-opening-quotes

### DIFF
--- a/numpydoc.el
+++ b/numpydoc.el
@@ -140,6 +140,13 @@ paragraph-filled."
   :group 'numpydoc
   :type 'boolean)
 
+(defcustom numpydoc-newline-after-opening-quotes t
+  "Flag to control insertion of newline after the opening quotes.
+If set to t a newline will be inserted after the opening quotes of
+the docstring to comply with numpydoc validation rule GL01."
+  :group 'numpydoc
+  :type 'boolean)
+
 ;;; package implementation code.
 
 (cl-defstruct numpydoc--def
@@ -385,10 +392,12 @@ This function assumes the cursor to be in the function body."
     (insert "\n")
     (numpydoc--insert indent
                       (concat (make-string 3 numpydoc-quote-char)
+                              (if numpydoc-newline-after-opening-quotes
+                                "\n    ")
                               (if (numpydoc--prompt-p)
                                   (read-string
                                    (format "Short description: "))
-                                tmps)
+                                   tmps)
                               "\n\n")
                       (make-string 3 numpydoc-quote-char))
     (forward-line -1)


### PR DESCRIPTION
Closes #19

Finally remembered to finish this off, sorry its taken so long.

Adds the suggested `numpydoc-newline-after-opening-quotes` as a custom boolean variable with a default of `t` (as suggested) to the `numpydoc` group.

This is then used in `numpydoc--insert-short-and-long-desc` to conditionally insert a new line as per [validation rule GL01](https://numpydoc.readthedocs.io/en/latest/validation.html#built-in-validation-checks).

